### PR TITLE
Make full error messages a bit more machine-friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ function makeError(code, message, options) {
   var column = options.column;
   var filename = options.filename;
   var src = options.src;
-  var fullMessage;
   var location = line + (column ? ':' + column : '');
+  var fullMessage = (filename || 'Jade') + ':' + location + ': ' + message;
   if (src) {
     var lines = src.split('\n');
     var start = Math.max(line - 3, 0);
@@ -20,9 +20,7 @@ function makeError(code, message, options) {
         + '| '
         + text;
     }).join('\n');
-    fullMessage = (filename || 'Jade') + ':' + location + '\n' + context + '\n\n' + message;
-  } else {
-    fullMessage = (filename || 'Jade') + ':' + location + '\n\n' + message;
+    fullMessage += '\n' + context + '\n';
   }
   var err = new Error(fullMessage);
   err.code = 'JADE:' + code;

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ var error = require('../');
 test('with a source', function () {
   test('and a filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3, filename: 'myfile', src: 'foo\nbar\nbaz\nbash\nbing'});
-    assert(err.message === 'myfile:3\n    1| foo\n    2| bar\n  > 3| baz\n    4| bash\n    5| bing\n\nMy message');
+    assert(err.message === 'myfile:3: My message\n    1| foo\n    2| bar\n  > 3| baz\n    4| bash\n    5| bing\n');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);
@@ -16,7 +16,7 @@ test('with a source', function () {
   });
   test('and no filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3, src: 'foo\nbar\nbaz\nbash\nbing'});
-    assert(err.message === 'Jade:3\n    1| foo\n    2| bar\n  > 3| baz\n    4| bash\n    5| bing\n\nMy message');
+    assert(err.message === 'Jade:3: My message\n    1| foo\n    2| bar\n  > 3| baz\n    4| bash\n    5| bing\n');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);
@@ -28,7 +28,7 @@ test('with a source', function () {
 test('without source', function () {
   test('and with a filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3, filename: 'myfile'});
-    assert(err.message === 'myfile:3\n\nMy message');
+    assert(err.message === 'myfile:3: My message');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);
@@ -37,7 +37,7 @@ test('without source', function () {
   });
   test('and with no filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3});
-    assert(err.message === 'Jade:3\n\nMy message');
+    assert(err.message === 'Jade:3: My message');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);
@@ -49,7 +49,7 @@ test('without source', function () {
 test('with column', function () {
   test('and with a filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3, column: 1, filename: 'myfile'});
-    assert(err.message === 'myfile:3:1\n\nMy message');
+    assert(err.message === 'myfile:3:1: My message');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);
@@ -58,7 +58,7 @@ test('with column', function () {
   });
   test('and with no filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3, column: 1});
-    assert(err.message === 'Jade:3:1\n\nMy message');
+    assert(err.message === 'Jade:3:1: My message');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);


### PR DESCRIPTION
This adopts a style different from the one in #1 so that it's a bit more similar to GCC:

```
Error: my.jade:2:3: mesg
    1| hey
  > 2| blah
    3| asdf

    at makeError (/home/timothy_gu/jade-error/index.js:25:13)
    at repl:1:19
    at REPLServer.defaultEval (repl.js:248:27)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:412:12)
    at emitOne (events.js:82:20)
    at REPLServer.emit (events.js:169:7)
    at REPLServer.Interface._onLine (readline.js:210:10)
    at REPLServer.Interface._line (readline.js:549:8)
```
