### PR TITLE
Add a marker for column as well as line

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,15 @@ function makeError(code, message, options) {
     // Error context
     var context = lines.slice(start, end).map(function(text, i){
       var curr = i + start + 1;
-      return (curr == line ? '  > ' : '    ')
+      var preamble = (curr == line ? '  > ' : '    ')
         + curr
-        + '| '
-        + text;
+        + '| ';
+      var out = preamble + text;
+      if (curr === line && column) {
+        out += '\n';
+        out += Array(preamble.length + column).join('-') + '^';
+      }
+      return out;
     }).join('\n');
     fullMessage = (filename || 'Jade') + ':' + location + '\n' + context + '\n\n' + message;
   } else {

--- a/test/index.js
+++ b/test/index.js
@@ -48,13 +48,13 @@ test('without source', function () {
 
 test('with column', function () {
   test('and with a filename', function () {
-    var err = error('MY_CODE', 'My message', {line: 3, column: 1, filename: 'myfile'});
-    assert(err.message === 'myfile:3:1\n\nMy message');
+    var err = error('MY_CODE', 'My message', {line: 3, column: 2, filename: 'myfile', src: 'foo\nbar\nbaz\nbash\nbing'});
+    assert(err.message === 'myfile:3:2\n    1| foo\n    2| bar\n  > 3| baz\n--------^\n    4| bash\n    5| bing\n\nMy message');
     assert(err.code === 'JADE:MY_CODE');
     assert(err.msg === 'My message');
     assert(err.line === 3);
     assert(err.filename === 'myfile');
-    assert(err.src === undefined);
+    assert(err.src === 'foo\nbar\nbaz\nbash\nbing');
   });
   test('and with no filename', function () {
     var err = error('MY_CODE', 'My message', {line: 3, column: 1});


### PR DESCRIPTION
Sample output:

```
    1| hey
  > 2| blah
---------^
    3| asdf
```

After #5 is merged:

```
Error: my.jade:2:3: mesg
    1| hey
  > 2| blah
---------^
    3| asdf

    at makeError (/home/timothy_gu/jade-error/index.js:30:13)
    at repl:1:19
    at REPLServer.defaultEval (repl.js:248:27)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:412:12)
    at emitOne (events.js:82:20)
    at REPLServer.emit (events.js:169:7)
    at REPLServer.Interface._onLine (readline.js:210:10)
    at REPLServer.Interface._line (readline.js:549:8)
```

Consistent with stylus'.
